### PR TITLE
Fix typo in test

### DIFF
--- a/01-coupling/tests/end_to_end_test.go
+++ b/01-coupling/tests/end_to_end_test.go
@@ -85,7 +85,7 @@ func testUserLifecycle(t *testing.T, client HTTPClient) {
 	userByID, ok := client.GetUser(user.ID)
 	require.True(t, ok, "Expected to find the user by ID")
 
-	require.Equal(t, firstName+" "+lastName, user.DisplayName)
+	require.Equal(t, firstName+" "+lastName, userByID.DisplayName)
 	require.Len(t, userByID.Emails, 1)
 
 	client.DeleteUser(user.ID)


### PR DESCRIPTION
Current test was a duplicate of the one above, re-testing the first user
instead of the one freshly pulled by ID.

Tests still passing:
```
⇒ make test
PASS
ok  	github.com/ThreeDotsLabs/go-web-app-antipatterns/tests	0.226s
```