### PR TITLE
Fix middleware order: Move Logger before Recoverer

### DIFF
--- a/01-coupling/01-tightly-coupled/cmd/main.go
+++ b/01-coupling/01-tightly-coupled/cmd/main.go
@@ -31,8 +31,8 @@ func main() {
 	h := internal.NewUserHandler(storage)
 
 	r := chi.NewRouter()
-	r.Use(middleware.Recoverer)
 	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
 
 	r.Route("/users", func(r chi.Router) {
 		r.Get("/", h.GetUsers)

--- a/01-coupling/02-loosely-coupled/cmd/main.go
+++ b/01-coupling/02-loosely-coupled/cmd/main.go
@@ -31,8 +31,8 @@ func main() {
 	h := internal.NewUserHandler(storage)
 
 	r := chi.NewRouter()
-	r.Use(middleware.Recoverer)
 	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
 
 	r.Route("/users", func(r chi.Router) {
 		r.Get("/", h.GetUsers)

--- a/01-coupling/03-loosely-coupled-generated/cmd/main.go
+++ b/01-coupling/03-loosely-coupled-generated/cmd/main.go
@@ -21,8 +21,8 @@ func main() {
 	h := internal.NewUserHandler(storage)
 
 	r := chi.NewRouter()
-	r.Use(middleware.Recoverer)
 	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
 
 	handler := internal.HandlerFromMux(h, r)
 

--- a/01-coupling/04-loosely-coupled-app-layer/cmd/main.go
+++ b/01-coupling/04-loosely-coupled-app-layer/cmd/main.go
@@ -21,8 +21,8 @@ func main() {
 	h := internal.NewUserHandler(storage)
 
 	r := chi.NewRouter()
-	r.Use(middleware.Recoverer)
 	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
 
 	handler := internal.HandlerFromMux(h, r)
 


### PR DESCRIPTION
This PR addresses an issue with the order of middleware in the router setup. According to the [chi documentation](https://go-chi.io/#/pages/middleware?id=logger), the Logger middleware should be placed before any other middleware that may change the response, such as Recoverer middleware. In the current implementation, the Logger middleware is placed after the Recoverer middleware, which may result in incorrect logging behavior.

Changes made:
- Moved the Logger middleware before the Recoverer middleware in the router setup.

By making this change, the middleware order will now be in compliance with chi's recommendations, ensuring proper logging behavior.
